### PR TITLE
us9-partners PR

### DIFF
--- a/config/packages/vich_uploader.yaml
+++ b/config/packages/vich_uploader.yaml
@@ -3,10 +3,14 @@ vich_uploader:
 
     mappings:
         vehicle_photo:
-            uri_prefix: /assets/images
+            uri_prefix: /assets/images/
             upload_destination: '%upload_directory%'
             namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
         charging_stations_photo:
+            uri_prefix: /assets/images/
+            upload_destination: '%upload_directory%'
+            namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
+        partner_icon:
             uri_prefix: /assets/images/
             upload_destination: '%upload_directory%'
             namer: Vich\UploaderBundle\Naming\SmartUniqueNamer

--- a/migrations/Version20210126144803.php
+++ b/migrations/Version20210126144803.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210126144803 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE partner (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, icon VARCHAR(255) NOT NULL, link VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE partner');
+    }
+}

--- a/src/Controller/AdminPartnersController.php
+++ b/src/Controller/AdminPartnersController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Doctrine\ORM\EntityManagerInterface;
+use App\Entity\Partner;
+use App\Form\CurrentPartnerType;
+use App\Repository\PartnerRepository;
+use App\Service\FileManager;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+
+/**
+ * @Route("/admin", name="admin_")
+ * @IsGranted("ROLE_ADMIN")
+ */
+class AdminPartnersController extends AbstractController
+{
+    /**
+     * Show all current partners
+     * @Route("/partenaires", name="current_partners")
+     */
+    public function currentPartner(PartnerRepository $partnerRepository): Response
+    {
+        return $this->render('admin/current_partners.html.twig', [
+            'partners' => $partnerRepository->findAll(),
+        ]);
+    }
+
+    /**
+     * Displays the page to add a new partner
+     * @Route("/partenaire/ajouter", name="current_partner_new", methods={"GET","POST"})
+     * @return Response
+     */
+    public function newCurrentPartner(Request $request, EntityManagerInterface $manager): Response
+    {
+        $partner = new Partner();
+        $form = $this->createForm(CurrentPartnerType::class, $partner);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $manager->persist($partner);
+
+            $manager->flush();
+
+            return $this->redirectToRoute('admin_current_partners');
+        }
+
+        return $this->render('admin/current_partner_new.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * Displays the page view partner details
+     * @Route("/partenaire/{id}", name="current_partner_show", methods={"GET"})
+     * @return Response
+     */
+    public function showCurrentPartner(Partner $partner): Response
+    {
+        return $this->render('admin/current_partner_show.html.twig', [
+            'partner' => $partner,
+        ]);
+    }
+
+    /**
+     * Provides access to the page to modify a partner's informations
+     * @Route("/partenaire/modifier/{id}", name="current_partner_edit", methods={"GET","POST"})
+     * @return Response
+     */
+    public function editCurrentPartner(
+        Request $request,
+        Partner $partner,
+        EntityManagerInterface $manager
+    ): Response {
+        $form = $this->createForm(CurrentPartnerType::class, $partner);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $manager->persist($partner);
+
+            $manager->flush();
+
+            return $this->redirectToRoute('admin_current_partners');
+        }
+
+        return $this->render('admin/current_partner_edit.html.twig', [
+            'partner' => $partner,
+            'form' => $form->createView(),
+        ]);
+    }
+
+
+    /**
+     * Deletes a partner
+     * @Route("/partenaire/supprimer/{id}", name="current_partner_delete", methods={"DELETE"})
+     * @return Response
+     */
+    public function deleteCurrentPartner(
+        Request $request,
+        Partner $partner,
+        EntityManagerInterface $manager
+    ): Response {
+        if ($this->isCsrfTokenValid('delete' . $partner->getId(), $request->request->get('_token'))) {
+            $manager->remove($partner);
+
+            $manager->flush();
+        }
+
+        return $this->redirectToRoute('admin_current_partners');
+    }
+}

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -2,7 +2,7 @@
 
 namespace App\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use App\Controller\FrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -17,13 +17,14 @@ use App\Form\EstimateCompaniesType;
 use App\DataClass\EstimateCompanies;
 use App\Form\ContactType;
 use App\DataClass\Contact;
+use App\Repository\PartnerRepository;
 use DateTime;
 
 /**
  * Creates the views that allow the users send information to Mobilean
  * @Route(name="contact_")
  */
-class ContactController extends AbstractController
+class ContactController extends FrontController
 {
     /**
      * Displays contact page

--- a/src/Controller/FrontController.php
+++ b/src/Controller/FrontController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use App\Repository\PartnerRepository;
+use App\Entity\Partner;
+
+/**
+ * Provides common features needed in front controllers
+ */
+abstract class FrontController extends AbstractController
+{
+    /**
+     * @var Partner[]
+     */
+    protected array $partners;
+
+    public function __construct(PartnerRepository $partnerRepository)
+    {
+        $this->partners = $partnerRepository->findAll();
+    }
+
+    /**
+     * Renders a view with partners
+     * @param mixed[] $parameters
+     */
+    protected function render(string $view, array $parameters = [], Response $response = null): Response
+    {
+        $parameters['partners'] = $this->partners;
+        $content = $this->renderView($view, $parameters);
+
+        if (null === $response) {
+            $response = new Response();
+        }
+
+        $response->setContent($content);
+
+        return $response;
+    }
+}

--- a/src/Controller/InformationController.php
+++ b/src/Controller/InformationController.php
@@ -2,15 +2,16 @@
 
 namespace App\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use App\Controller\FrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use App\Repository\PartnerRepository;
 
 /**
  * Creates complementary views
  * @Route(name="information_")
  */
-class InformationController extends AbstractController
+class InformationController extends FrontController
 {
     /**
      * Displays informations about Mobilean

--- a/src/Controller/ProductController.php
+++ b/src/Controller/ProductController.php
@@ -2,17 +2,18 @@
 
 namespace App\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use App\Controller\FrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use App\Repository\VehicleRepository;
 use App\Repository\RefillStationRepository;
+use App\Repository\PartnerRepository;
 
 /**
  * Creates views that allow users to see the different products
  * @Route(name="product_")
  */
-class ProductController extends AbstractController
+class ProductController extends FrontController
 {
     /**
      * Displays home page

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PartnerRepository;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\HttpFoundation\File\File;
+use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass=PartnerRepository::class)
+ * @Vich\Uploadable
+ */
+class Partner
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private int $id;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=false)
+     * @Assert\NotBlank()
+     * @Assert\Length(min=2, max=255)
+     */
+    private ?string $name;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=false)
+     */
+    private ?string $icon = "";
+
+    /**
+     * @Assert\NotBlank()
+     * @Vich\UploadableField(mapping="partner_icon", fileNameProperty="icon")
+     */
+    private ?File $partnerIcon;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     * @Assert\Length(min=2, max=255)
+     */
+    private ?string $link;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getIcon(): ?string
+    {
+        return $this->icon;
+    }
+
+    public function setIcon(?string $icon): self
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function getPartnerIcon(): ?File
+    {
+        return $this->partnerIcon;
+    }
+
+    public function setPartnerIcon(?File $partnerIcon): self
+    {
+        $this->partnerIcon = $partnerIcon;
+
+        return $this;
+    }
+
+    public function getLink(): ?string
+    {
+        return $this->link;
+    }
+
+    public function setLink(?string $link): self
+    {
+        $this->link = $link;
+
+        return $this;
+    }
+}

--- a/src/Entity/RefillStation.php
+++ b/src/Entity/RefillStation.php
@@ -65,7 +65,7 @@ class RefillStation
     private ?string $photo = "";
 
     /**
-     * @Vich\UploadableField(mapping="vehicle_photo", fileNameProperty="photo")
+     * @Vich\UploadableField(mapping="charging_stations_photo", fileNameProperty="photo")
      */
     private ?File $chargingStationPhoto = null;
 

--- a/src/Form/CurrentPartnerType.php
+++ b/src/Form/CurrentPartnerType.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Partner;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Vich\UploaderBundle\Form\Type\VichFileType;
+
+class CurrentPartnerType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'Nom ou raison sociale du partenaire : ',
+            ])
+
+            ->add('link', UrlType::class, [
+                'label' => 'Lien vers le site du partenaire : ',
+                'required' => false,
+            ])
+
+            ->add('partnerIcon', VichFileType::class, [
+                'allow_delete'  => true,
+                'download_uri' => true,
+                'label' => 'Logo du partenaire : '
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Partner::class,
+        ]);
+    }
+}

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Partner;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Partner|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Partner|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Partner[]    findAll()
+ * @method Partner[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class PartnerRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Partner::class);
+    }
+
+    // /**
+    //  * @return Partner[] Returns an array of Partner objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('p.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?Partner
+    {
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/templates/admin/admin_layout.html.twig
+++ b/templates/admin/admin_layout.html.twig
@@ -18,6 +18,9 @@
 			<li class="nav-item">
 				<a class="nav-link" href="{{path('admin_partners')}}">Demandes de partenariat</a>
 			</li>
+            <li class="nav-item">
+				<a class="nav-link" href="{{path('admin_current_partners')}}">Partenaires</a>
+			</li>
 			<li class="nav-item">
 				<a class="nav-link" href="{{path('product_vehicles')}}">Revenir au site utilisateur</a>
 			</li>

--- a/templates/admin/current_partner_delete_form.html.twig
+++ b/templates/admin/current_partner_delete_form.html.twig
@@ -1,0 +1,5 @@
+<form method="post" action="{{ path('admin_current_partner_delete', {'id': partner.id}) }}" onsubmit="return confirm('Etes vous sur de vouloir supprimer cet élement?');">
+    <input type="hidden" name="_method" value="DELETE">
+    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ partner.id) }}">
+    <button class="btn btn-danger">Supprimer</button>
+</form>

--- a/templates/admin/current_partner_edit.html.twig
+++ b/templates/admin/current_partner_edit.html.twig
@@ -1,0 +1,17 @@
+{% extends 'admin/admin_layout.html.twig' %}
+
+{% block title %}{{ parent() }} - Admin - Modifier un partenaire{% endblock %}
+
+{% block body %}
+    <h1>Modifier le partenaire</h1>
+        <div class="page-form-edit">
+            <div class="form-edit">
+                {{ include('admin/current_partner_form.html.twig') }}
+            </div>
+            <div class="form-edit">
+                {{ include('admin/current_partner_delete_form.html.twig') }}
+            </div>
+            <a href="{{ path('admin_current_partners') }}">Retour sur les partenaires</a>
+        </div>
+    
+{% endblock %}

--- a/templates/admin/current_partner_form.html.twig
+++ b/templates/admin/current_partner_form.html.twig
@@ -1,0 +1,4 @@
+{{ form_start(form) }}
+    {{ form_widget(form) }}
+    <button class="btn btn-success">{{ button_label|default('Mettre à jour') }}</button>
+{{ form_end(form) }}

--- a/templates/admin/current_partner_new.html.twig
+++ b/templates/admin/current_partner_new.html.twig
@@ -1,0 +1,11 @@
+{% extends 'admin/admin_layout.html.twig' %}
+
+{% block title %}{{ parent() }} - Admin - Nouveau partenaire{% endblock %}
+
+{% block body %}
+    <h1>Ajouter un nouveau partenaire</h1>
+        <div class="page-form-edit">
+            {{ include('admin/current_partner_form.html.twig') }}
+            <a href="{{ path('admin_current_partners') }}">Retour sur les partenaires</a>
+        </div>
+{% endblock %}

--- a/templates/admin/current_partner_show.html.twig
+++ b/templates/admin/current_partner_show.html.twig
@@ -1,0 +1,39 @@
+{% extends 'admin/admin_layout.html.twig' %}
+
+{% block title %}{{ parent() }} - Admin - Partenaire{% endblock %}
+
+{% block body %}
+    <h1>Partenaire</h1>
+
+    <table class="table-show-refill table table-hover">
+        <tbody>
+            <tr>
+                <th scope="col">Id</th>
+                <td>{{ partner.id }}</td>
+            </tr>
+            <tr>
+                <th scope="col">Nom</th>
+                <td>{{ partner.name }}</td>
+            </tr>
+            <tr>
+                <th scope="col">Logo</th>
+                <td><img src="/assets/images/uploads/{{ partner.icon }}" alt="logo de {{ partner.name }}"></td>
+            </tr>
+            <tr>
+                <th scope="col">Site internet</th>
+                <td>{{ partner.link }}</td>
+            </tr>
+        </tbody>
+        <tfoot>
+            <th>
+                <a href="{{ path('admin_current_partners') }}">Retour sur les partenaires</a>
+            </th>
+        </tfoot>
+    </table>
+
+    <div class="button-action">
+        <a class="btn btn-success"href="{{ path('admin_current_partner_edit', {'id': partner.id}) }}" role="button">Modifier</a>
+        {{ include('admin/current_partner_delete_form.html.twig') }}
+    </div>
+    
+{% endblock %}

--- a/templates/admin/current_partners.html.twig
+++ b/templates/admin/current_partners.html.twig
@@ -1,0 +1,37 @@
+{# This is the page that will allow admins to see their current partners #}
+
+{% extends 'admin/admin_layout.html.twig' %}
+
+{% block title %}{{ parent() }} - Admin - Partenaires {% endblock %}
+
+{% block body %}
+<h1>Partenaires</h1>
+<table class="table-refill table table-hover"> 
+        <thead>
+            <tr>
+                <th scope="col">Nom</th>
+                <th scope="col">Logo</th>
+                <th scope="col">Lien vers le site</th>
+                <th scope="col">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for partner in partners %}
+            <tr>
+                <td>{{ partner.name }}</td>
+                <td><img src="/assets/images/uploads/{{ partner.icon }}" alt="logo de {{ partner.name }}"></td>
+                <td>{{ partner.link }}</td>
+                <td>
+                    <a class="btn btn-outline-info" href="{{ path('admin_current_partner_show', {'id': partner.id}) }}" roles="button">Details</a>
+                    <a class="btn btn-outline-info" href="{{ path('admin_current_partner_edit', {'id': partner.id}) }}" roles="button">Modifier</a>
+                </td>
+            </tr>
+        {% else %}
+            <tr>
+                <td colspan="9">Aucun partenaire trouvé</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <a class=" btn-add btn btn-success"href="{{ path('admin_current_partner_new') }}" role="button">Ajouter un partenaire</a>
+{% endblock %}

--- a/templates/front/front_layout.html.twig
+++ b/templates/front/front_layout.html.twig
@@ -45,4 +45,10 @@
 {% block footer %}
     <p class="footer-block"> <a class="nav-link-footer" href="{{path('contact_message')}}">Contactez-nous</a></p>
     <p class="footer-block"><a class="nav-link-footer" href="{{path('information_legal')}}">Mentions légales</a></p>
+    <p>Nos Partenaires : </p>
+    {% for partner in partners %}
+        <a href="{{partner.link}}">
+            <img src="/assets/images/uploads/{{ partner.icon }}" alt="logo de {{ partner.name }}">
+        </a>
+    {% endfor %}
 {% endblock %}


### PR DESCRIPTION
created controllers and views to let admins add current partners to database and display them in footer

note : this PR contains a migration, don't forget to run symfony console doctrine:migrations:migrate after pulling it
also : the code produced in this PR is not 100% clear due to the fact that 'partner(s)' may refer to different things depending on where you look at in the code. this is absolutely not ideal and should be looked at in the near future for code readability.